### PR TITLE
Update doc example to use new event API syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.1
+  - Docs: Update doc example to use new event API syntax 
+# 3.0.0
+  - Update plugin to the new event API
 # 2.0.4
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
 # 2.0.3

--- a/lib/logstash/outputs/librato.rb
+++ b/lib/logstash/outputs/librato.rb
@@ -64,7 +64,7 @@ class LogStash::Outputs::Librato < LogStash::Outputs::Base
   # Annotations
   # Registers an annotation with Librato
   # The only required field is `title` and `name`.
-  # `start_time` and `end_time` will be set to `event["@timestamp"].to_i`
+  # `start_time` and `end_time` will be set to `event.get("@timestamp").to_i`
   # You can add any other optional annotation values as well.
   # All values will be passed through `event.sprintf`
   #

--- a/logstash-output-librato.gemspec
+++ b/logstash-output-librato.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-librato'
-  s.version         = '3.0.0'
+  s.version         = '3.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output lets you send metrics, annotations and alerts to Librato based on Logstash events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
I also noticed that the changelog didn't get updated when the version was bumped to 3.0.0, so I added an entry for 3.0.0.